### PR TITLE
Decouple d3 rendering logic from component logic

### DIFF
--- a/app/components/visualizer/main-viz/templates/DonutChart/DonutChart.js
+++ b/app/components/visualizer/main-viz/templates/DonutChart/DonutChart.js
@@ -6,7 +6,6 @@ class Configurator {
   constructor(config = {}) {
     let defaults = {
       accessors: {},
-      colors: ["#6B0C22", "#D9042B", "#F4CB89", "#588C8C", "#011C26"],
       data: {
         "A": 0.2,
         "B": 0.2,
@@ -14,8 +13,7 @@ class Configurator {
         "D": 0.2,
         "F": 0.2
       },
-      element: "body",
-      fields: {},
+      element: "#main-viz",
       height: 512,
       id: "_id",
       label: "DonutChart",
@@ -23,7 +21,7 @@ class Configurator {
       transitionTime: 1000
     };
 
-    this.config = () => { return _.merge(defaults, config); };
+    this.config = () => { return _.defaults(config, defaults); };
   }
 }
 
@@ -37,17 +35,11 @@ class DonutChart {
       .outerRadius(this.radius * 0.8)
       .innerRadius(this.radius * 0.4);
 
-    this.color = d3.scale.ordinal()
-      .domain(this.config.fields)
-      .range(this.config.colors);
-
     this.pie = d3.layout.pie()
       .sort(null)
-      .value((d) => { return d.value; });
+      .value((d) => { return d[1]; });
 
     this.svg = d3.select(this.config.element).append("g");
-
-    this.key = this.config.accessors.label;
   }
 
   create() {
@@ -56,9 +48,9 @@ class DonutChart {
     this.loadVisualization(data);
   }
 
-  update(data) {
-    console.log(data);
-    this.config.data = data;
+  update(major) {
+    this.config.data = major.data;
+    this.config.id = major.id;
     let d = this.coerceDataIntoUsableForm();
     this.loadVisualization(d);
   }
@@ -81,16 +73,9 @@ class DonutChart {
 
   // TODO: Decouple the data ceorcion logic
   coerceDataIntoUsableForm() {
-    let labels = this.color.domain();
-    let discoveredObj = this.config.data;
-    let values = labels.map((label) => {
-      return {
-        label: label,
-        value: discoveredObj[label]
-      };
-    });
+    let values = _.pairs(this.config.data);
 
-    return { title: discoveredObj[this.config.id], values: values };
+    return { title: this.config.id, values: values };
   }
 
   createPieSlices(values) {
@@ -98,17 +83,14 @@ class DonutChart {
 
     let slice = this.svg.select(".slices")
       .selectAll("path.slice")
-      .data(this.pie(values), this.key);
+      .data(this.pie(values));
 
     slice.enter()
       .insert("path")
-      .style("fill", (d) => { return this.color(d.data.label); })
       .attr("class", "slice");
 
     slice.transition()
       .duration(this.config.transitionTime)
-      // Arrow functions are not only syntactical sugar, they lexically bind
-      // 'this'!
       .attrTween("d", function(d) {
         this.current = this.current || d;
         let interpolateIt = d3.interpolate(this.current, d);
@@ -122,12 +104,14 @@ class DonutChart {
 
   createTextLabels(values) {
     let text = this.svg.select(".labels").selectAll("text")
-      .data(this.pie(values), this.key);
+    .data(this.pie(values), (d) => {
+      return d.data[0];
+    });
 
     text.enter()
       .append("text")
       .attr("dy", ".35em")
-      .text((d) => { return this.config.label(d.data); })
+      .text((d) => { return d.data[0]; })
       .style("font-weight", "bold")
       .style("font-size", "34px")
       .style("fill", "White");
@@ -148,7 +132,7 @@ class DonutChart {
   }
 
   createTitle(title) {
-    this.svg
+    return this.svg
       .select(".title")
       .select("text")
       .text(title);

--- a/app/components/visualizer/main-viz/templates/DonutChart/DonutChart.js
+++ b/app/components/visualizer/main-viz/templates/DonutChart/DonutChart.js
@@ -7,12 +7,18 @@ class Configurator {
     let defaults = {
       accessors: {},
       colors: ["#6B0C22", "#D9042B", "#F4CB89", "#588C8C", "#011C26"],
-      data: {},
+      data: {
+        "A": 0.2,
+        "B": 0.2,
+        "C": 0.2,
+        "D": 0.2,
+        "F": 0.2
+      },
       element: "body",
       fields: {},
       height: 512,
       id: "_id",
-      label: (n) => { return n; },
+      label: "DonutChart",
       width: 1024,
       transitionTime: 1000
     };
@@ -50,9 +56,11 @@ class DonutChart {
     this.loadVisualization(data);
   }
 
-  update() {
-    let data = this.coerceDataIntoUsableForm();
-    this.loadVisualization(data);
+  update(data) {
+    console.log(data);
+    this.config.data = data;
+    let d = this.coerceDataIntoUsableForm();
+    this.loadVisualization(d);
   }
 
   setupSvg() {
@@ -74,7 +82,7 @@ class DonutChart {
   // TODO: Decouple the data ceorcion logic
   coerceDataIntoUsableForm() {
     let labels = this.color.domain();
-    let discoveredObj = _.sample(this.config.data);
+    let discoveredObj = this.config.data;
     let values = labels.map((label) => {
       return {
         label: label,

--- a/app/components/visualizer/main-viz/templates/DonutChart/DonutChartComponent.jsx
+++ b/app/components/visualizer/main-viz/templates/DonutChart/DonutChartComponent.jsx
@@ -7,30 +7,22 @@ class DonutChartComponent extends React.Component {
 
   plot() {
     if (!this.chart) {
+      let d = this.filterData(this.props.data);
+
       this.chart = new DonutChart({
-        id: "_id",
-        data: this.filterData(this.props.data),
-        element: "#main-viz",
-        height: 512,
-        width: 1024,
-        fields: [
-          "PCT_A",
-          "PCT_B",
-          "PCT_C",
-          "PCT_D",
-          "PCT_F"
-        ],
-        label: (d) => { return d.label.replace("PCT_", ""); },
-        accessors: {
-          label: (d) => { return d.data.label; }
-        }
+        id: d.major,
+        data: d.data
       });
     }
 
     // Ghetto: but shows working update.
     // TODO: Remove this loaded logic
     if (this.loaded) {
-      this.chart.update(this.filterData(this.props.data));
+      let d = this.filterData(this.props.data);
+      this.chart.update({
+        id: d.major,
+        data: d.data
+      });
     } else {
       this.chart.create();
       this.loaded = true;
@@ -48,7 +40,24 @@ class DonutChartComponent extends React.Component {
   }
 
   filterData(data) {
-    return _.sample(data);
+    let d = _.sample(data);
+    let major = d._id;
+
+    let prepareDataForViz = (obj) => {
+      // Filter for percentages greater than 0
+      let keys = _.filter(Object.keys(obj), (key) => { return obj[key] > 0; });
+
+      // Get the vals of the keys so we can zip them together later
+      let vals = _.map(keys, (key) => { return obj[key]; });
+
+      // Get last letter of the string
+      let parsedKeys = keys.map((key) => { return key.slice(-1); });
+
+      // Combine keys and vals into an object
+      return _.zipObject(parsedKeys, vals);
+    };
+
+    return {major: major, data: prepareDataForViz(d)};
   }
 }
 

--- a/app/components/visualizer/main-viz/templates/DonutChart/DonutChartComponent.jsx
+++ b/app/components/visualizer/main-viz/templates/DonutChart/DonutChartComponent.jsx
@@ -9,7 +9,7 @@ class DonutChartComponent extends React.Component {
     if (!this.chart) {
       this.chart = new DonutChart({
         id: "_id",
-        data: this.props.data,
+        data: this.filterData(this.props.data),
         element: "#main-viz",
         height: 512,
         width: 1024,
@@ -30,7 +30,7 @@ class DonutChartComponent extends React.Component {
     // Ghetto: but shows working update.
     // TODO: Remove this loaded logic
     if (this.loaded) {
-      this.chart.update();
+      this.chart.update(this.filterData(this.props.data));
     } else {
       this.chart.create();
       this.loaded = true;
@@ -45,6 +45,10 @@ class DonutChartComponent extends React.Component {
     }
 
     return <div className="Chart"></div>;
+  }
+
+  filterData(data) {
+    return _.sample(data);
   }
 }
 


### PR DESCRIPTION
In order to make the charts as reusable as possible, the chart needs to be as simple as possible and not deal with any of the logic regarding parsing data. This means the user is responsible, in some manner, of making sure the data is in a consumable form for the chart. 

In this case, the chart isn't very needy. In fact, you don't have to give it anything and it will still work. In reality though, you would want to pass some data in the form of an key/value object following the form `{ key: String => value: float }`. There are other options, such as height/width which can be passed as well.

This brings us one step closer to the end goal of having pluggable d3 components, which do not really care what data you throw at it.
